### PR TITLE
User info model and serializier

### DIFF
--- a/tressreliefapi/models/__init__.py
+++ b/tressreliefapi/models/__init__.py
@@ -1,0 +1,1 @@
+from .user_info import UserInfo

--- a/tressreliefapi/models/user_info.py
+++ b/tressreliefapi/models/user_info.py
@@ -1,0 +1,24 @@
+from django.db import models
+
+
+class UserInfo(models.Model):
+    class Roles(models.TextChoices):  # enum helper for string fields
+        CLIENT = "client", "Client", "CLIENT"
+        STYLIST = "stylist", "Stylist", "STYLIST"
+        ADMIN = "admin", "Admin", "ADMIN"
+
+    # from google/firebase auth:
+    uid = models.CharField(max_length=128, unique=True)
+    # blank=True: means field not required (it's allowed to be blank)
+    display_name = models.CharField(max_length=255, blank=True)
+    google_email = models.EmailField(blank=True)
+    # default or updated:
+    role = models.CharField(
+        max_length=20,
+        choices=Roles.choices,  # restricts values to the enum
+        default=Roles.CLIENT,
+    )
+    # set only when obj is first created and saved to db
+    created_at = models.DateTimeField(auto_now_add=True)
+    # set every time obj is saved regardless
+    updated_at = models.DateTimeField(auto_now=True)

--- a/tressreliefapi/serializers/user_info.py
+++ b/tressreliefapi/serializers/user_info.py
@@ -1,0 +1,12 @@
+from rest_framework import serializers
+from models import UserInfo
+
+
+class UserInfoSerializer(serializers.ModelSerialzier):
+    """JSON Serializer for user info"""
+    class Meta:
+        model = UserInfo
+        fields = ("id", "uid", "display_name", "google_email",
+                  "role", "created_at", "updated_at")
+        # Fields listed in read_only_fields will be returned in responses but ignored on incoming writes. Mark server-managed stuff (PK and timestamps) as read-only so clients can’t set them.
+        read_only_fields = ("id", "created_at", "updated_at")


### PR DESCRIPTION
This pull request introduces a new user information model to the backend, along with its serializer, to support storing and retrieving user profile data. The main changes include defining the `UserInfo` Django model, registering it in the models package, and creating a corresponding serializer for API responses.

**User model and serializer additions:**

* Introduced the `UserInfo` Django model in `user_info.py`, which includes fields for `uid`, `display_name`, `google_email`, `role` (with enum choices for client, stylist, and admin), and timestamp fields for creation and updates.
* Registered the new `UserInfo` model in the models package by importing it in `__init__.py`.

**API serialization:**

* Added a `UserInfoSerializer` in `serializers/user_info.py` to handle JSON serialization and deserialization of the `UserInfo` model, marking certain fields as read-only for API clients.

Closes tickets [#8](https://github.com/alyssacleland/tressrelief-client/issues/8) and [#14](https://github.com/alyssacleland/tressrelief-client/issues/14)