### PR TITLE
user_info auth view, updated serializer, altered permissions in settings.py

### DIFF
--- a/tressreliefapi/serializers/__init__.py
+++ b/tressreliefapi/serializers/__init__.py
@@ -1,0 +1,1 @@
+from .user_info import UserInfoSerializer

--- a/tressreliefapi/serializers/user_info.py
+++ b/tressreliefapi/serializers/user_info.py
@@ -1,8 +1,8 @@
 from rest_framework import serializers
-from models import UserInfo
+from tressreliefapi.models import UserInfo
 
 
-class UserInfoSerializer(serializers.ModelSerialzier):
+class UserInfoSerializer(serializers.ModelSerializer):
     """JSON Serializer for user info"""
     class Meta:
         model = UserInfo

--- a/tressreliefapi/views/__init__.py
+++ b/tressreliefapi/views/__init__.py
@@ -1,0 +1,1 @@
+from .auth import get_or_create_user

--- a/tressreliefapi/views/auth.py
+++ b/tressreliefapi/views/auth.py
@@ -1,0 +1,29 @@
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework import status
+from tressreliefapi.models import UserInfo
+from tressreliefapi.serializers import UserInfoSerializer
+
+
+@api_view(["POST"])
+def get_or_create_user(request):
+    """
+    Body:
+      {
+        "uid": "<firebase uid>",
+        "display_name": "<optional>",
+        "google_email": "<optional>"
+      }
+    Returns the existing user or creates one with role='client'.
+    """
+    uid = request.data.get("uid")
+    if not uid:
+        return Response({"detail": "Missing uid"}, status=status.HTTP_400_BAD_REQUEST)
+
+    defaults = {
+        "display_name": request.data.get("display_name") or "",
+        "google_email": request.data.get("google_email") or "",
+    }
+
+    user, _ = UserInfo.objects.get_or_create(uid=uid, defaults=defaults)
+    return Response(UserInfoSerializer(user).data, status=status.HTTP_200_OK)

--- a/tressreliefproject/settings.py
+++ b/tressreliefproject/settings.py
@@ -32,14 +32,22 @@ INSTALLED_APPS = [
     'tressreliefapi',
 ]
 
+# REST_FRAMEWORK = {
+#     'DEFAULT_AUTHENTICATION_CLASSES': (
+#         'rest_framework.authentication.TokenAuthentication',
+#     ),
+#     'DEFAULT_PERMISSION_CLASSES': [
+#         'rest_framework.permissions.IsAuthenticated',
+#     ],
+# }
+
 REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework.authentication.TokenAuthentication',
+    'DEFAULT_AUTHENTICATION_CLASSES': (),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.AllowAny',
     ),
-    'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated',
-    ],
 }
+
 
 CORS_ORIGIN_WHITELIST = (
     'http://localhost:3000',
@@ -132,4 +140,3 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/4.0/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
-

--- a/tressreliefproject/urls.py
+++ b/tressreliefproject/urls.py
@@ -1,10 +1,12 @@
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
+from tressreliefapi.views.auth import get_or_create_user
 
 router = routers.DefaultRouter(trailing_slash=False)
 
 urlpatterns = [
     path('', include(router.urls)),
+    path("admin/", admin.site.urls),
+    path("get-or-create-user", get_or_create_user),
 ]
-


### PR DESCRIPTION
This pull request introduces a new API endpoint for getting or creating a user, updates serializer imports, and changes authentication and permission settings to allow open access by default. The main changes are grouped below.

**New API endpoint for user management:**

* Added `get_or_create_user` view in `tressreliefapi/views/auth.py` to handle POST requests for retrieving or creating users based on a Firebase UID, and registered this endpoint in `tressreliefproject/urls.py`. [[1]](diffhunk://#diff-4568d8f173380171a16e2c5b9be8857c5df1428264b2a2e1d19052677c2ea351R1-R29) [[2]](diffhunk://#diff-07fa7addfaca10eac40f9be921e954766b7dc506a7aa943b9b1f18c70ee98f81R4-L10)
* Imported `get_or_create_user` in `tressreliefapi/views/__init__.py` for proper module exposure.

**Serializer improvements:**

* Fixed the import and class name typo in `UserInfoSerializer` and imported it in `tressreliefapi/serializers/__init__.py` for easier access. [[1]](diffhunk://#diff-4b286773d984b5ab8c4795f37e552c43aef47a759ab1c131ed7ce7aaa52689ebL2-R5) [[2]](diffhunk://#diff-0e8f40258682dd4eb3ca4c084ee99ad6f3c254a16bb37346265714c13fa2788fR1)

**Authentication and permissions:**

* Changed `REST_FRAMEWORK` settings in `tressreliefproject/settings.py` to allow any user by default and disabled authentication requirements, making the API open for development/testing.

Other:

* Minor whitespace cleanup in `tressreliefproject/settings.py`.