### PR TITLE
list and retrieve methods for category

### DIFF
--- a/tressreliefapi/serializers/__init__.py
+++ b/tressreliefapi/serializers/__init__.py
@@ -1,1 +1,4 @@
 from .user_info import UserInfoSerializer
+from .category import CategorySerializer
+from .service import ServiceSerializer
+from .stylist_service import StylistServiceSerializer

--- a/tressreliefapi/serializers/stylist_service.py
+++ b/tressreliefapi/serializers/stylist_service.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 from tressreliefapi.models import StylistService
 
 
-class CategorySerializer(serializers.ModelSerializer):
+class StylistServiceSerializer(serializers.ModelSerializer):
     """JSON Serializer for stylist_service join table"""
 
     class Meta:

--- a/tressreliefapi/views/__init__.py
+++ b/tressreliefapi/views/__init__.py
@@ -1,2 +1,3 @@
 from .auth import get_or_create_user
 from .user_info import UserInfoView
+from .category import CategoryView

--- a/tressreliefapi/views/category.py
+++ b/tressreliefapi/views/category.py
@@ -1,0 +1,26 @@
+"""View module for handling requests about categories"""
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from tressreliefapi.models import Category
+from tressreliefapi.serializers import CategorySerializer
+
+
+class CategoryView(ViewSet):
+    def list(self, request):
+        """
+        Handle GET requests for categories
+        """
+        categories = Category.objects.all()
+        serializer = CategorySerializer(categories, many=True)
+        return Response(serializer.data)
+
+    def retrieve(self, request, pk):
+        """Handle GET requests for single category"""
+        category = Category.objects.get(pk=pk)
+        try:
+            serializer = CategorySerializer(category)
+            return Response(serializer.data)
+        except Category.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)

--- a/tressreliefapi/views/service.py
+++ b/tressreliefapi/views/service.py
@@ -1,0 +1,6 @@
+"""View module for handling requests about services"""
+from django.http import HttpResponseServerError
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rest_framework import serializers, status
+from tressreliefapi.models import Service

--- a/tressreliefproject/urls.py
+++ b/tressreliefproject/urls.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
-from tressreliefapi.views import get_or_create_user, UserInfoView
+from tressreliefapi.views import get_or_create_user, UserInfoView, CategoryView
 
 
 # The first parameter, r'userinfo, is setting up the url.
@@ -10,6 +10,7 @@ from tressreliefapi.views import get_or_create_user, UserInfoView
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'userinfo', UserInfoView, 'userinfo')
+router.register(r'categories', CategoryView, 'category')
 
 # Each path() in urlpatterns is mapping a URL pattern to a view — which is just the code that runs when someone visits that URL.
 urlpatterns = [


### PR DESCRIPTION
This pull request introduces support for handling categories in the API, including the ability to list and retrieve category data. It adds a new `CategoryView`, registers it with the router, and ensures the appropriate serializers are imported and available. The most important changes are grouped below.

**Category API support:**

* Added `CategoryView` to handle GET requests for listing and retrieving categories (`tressreliefapi/views/category.py`, `tressreliefapi/views/__init__.py`). [[1]](diffhunk://#diff-6c2ca3dc8a7c783239e6a36536c92d0aa7f49d2107383e6a153cec9110a02c5dR1-R26) [[2]](diffhunk://#diff-e909aab695b34a22169e9eea05817ac60db99e0c61f2358a549e98a09cef1e44R3)
* Registered the new `CategoryView` with the router to expose `/categories` endpoints (`tressreliefproject/urls.py`). [[1]](diffhunk://#diff-07fa7addfaca10eac40f9be921e954766b7dc506a7aa943b9b1f18c70ee98f81L4-R4) [[2]](diffhunk://#diff-07fa7addfaca10eac40f9be921e954766b7dc506a7aa943b9b1f18c70ee98f81R13)

**Serializer imports and definitions:**

* Added imports for `CategorySerializer`, `ServiceSerializer`, and `StylistServiceSerializer` to the serializers module (`tressreliefapi/serializers/__init__.py`).
* Fixed the class name in `stylist_service.py` to correctly define `StylistServiceSerializer` instead of `CategorySerializer` (`tressreliefapi/serializers/stylist_service.py`).

**Service view module:**

* Added a new module for handling service-related requests, laying the groundwork for future service endpoints (`tressreliefapi/views/service.py`).