### PR TITLE
seeded join table fixture

### DIFF
--- a/tressreliefapi/fixtures/stylists_services.json
+++ b/tressreliefapi/fixtures/stylists_services.json
@@ -1,0 +1,28 @@
+[
+  { "model": "tressreliefapi.stylistservice", "pk": 1,  "fields": { "stylist": 4, "service": 1 } },
+  { "model": "tressreliefapi.stylistservice", "pk": 2,  "fields": { "stylist": 5, "service": 1 } },
+
+  { "model": "tressreliefapi.stylistservice", "pk": 3,  "fields": { "stylist": 4, "service": 2 } },
+  { "model": "tressreliefapi.stylistservice", "pk": 4,  "fields": { "stylist": 5, "service": 2 } },
+
+  { "model": "tressreliefapi.stylistservice", "pk": 5,  "fields": { "stylist": 4, "service": 3 } },
+  { "model": "tressreliefapi.stylistservice", "pk": 6,  "fields": { "stylist": 5, "service": 3 } },
+
+  { "model": "tressreliefapi.stylistservice", "pk": 7,  "fields": { "stylist": 4, "service": 4 } },
+  { "model": "tressreliefapi.stylistservice", "pk": 8,  "fields": { "stylist": 5, "service": 4 } },
+
+  { "model": "tressreliefapi.stylistservice", "pk": 9,  "fields": { "stylist": 4, "service": 5 } },
+  { "model": "tressreliefapi.stylistservice", "pk": 10, "fields": { "stylist": 5, "service": 5 } },
+
+  { "model": "tressreliefapi.stylistservice", "pk": 11, "fields": { "stylist": 4, "service": 6 } },
+  { "model": "tressreliefapi.stylistservice", "pk": 12, "fields": { "stylist": 5, "service": 6 } },
+
+  { "model": "tressreliefapi.stylistservice", "pk": 13, "fields": { "stylist": 4, "service": 7 } },
+  { "model": "tressreliefapi.stylistservice", "pk": 14, "fields": { "stylist": 5, "service": 7 } },
+
+  { "model": "tressreliefapi.stylistservice", "pk": 15, "fields": { "stylist": 4, "service": 8 } },
+  { "model": "tressreliefapi.stylistservice", "pk": 16, "fields": { "stylist": 5, "service": 8 } },
+
+  { "model": "tressreliefapi.stylistservice", "pk": 17, "fields": { "stylist": 4, "service": 9 } },
+  { "model": "tressreliefapi.stylistservice", "pk": 18, "fields": { "stylist": 5, "service": 10 } }
+]


### PR DESCRIPTION
This pull request adds a new fixture file to seed the database with sample data linking stylists to services. This will help with testing and development by providing predefined relationships between stylists and the services they offer.

**Fixture data addition:**

* Added `stylists_services.json` fixture with entries associating stylists (IDs 4 and 5) with various services (IDs 1–10) for the `stylistservice` model.