### PR TITLE
completed remaining views for MVP

### DIFF
--- a/tressreliefapi/views/service.py
+++ b/tressreliefapi/views/service.py
@@ -3,8 +3,9 @@ from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers, status
-from tressreliefapi.models import Service, Category
-from tressreliefapi.serializers import ServiceSerializer
+from tressreliefapi.models import Service, Category, StylistService, UserInfo
+from tressreliefapi.serializers import ServiceSerializer, UserInfoSerializer
+from rest_framework.decorators import action
 
 
 class ServiceView(ViewSet):
@@ -32,7 +33,6 @@ class ServiceView(ViewSet):
         return Response(serializer.data)
 
     # /services/:id
-
     def retrieve(self, request, pk):
         """Handle GET requests for single service"""
         try:
@@ -40,4 +40,100 @@ class ServiceView(ViewSet):
             serializer = ServiceSerializer(service)
             return Response(serializer.data)
         except Service.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+    # /services
+    def create(self, request):
+        """Handle POST operations"""
+        category = Category.objects.get(pk=request.data["category"])
+
+        service = Service.objects.create(
+            category=category,
+            name=request.data["name"],
+            description=request.data["description"],
+            duration=request.data["duration"],
+            price=request.data["price"],
+            # default to empty string if not provided. model allows empty with blank=True
+            image_url=request.data.get("image_url", ""),
+            active=request.data.get("active", True)
+            # leave out created_at and updated_at because they are set automatically via my model definition
+        )
+        serializer = ServiceSerializer(service)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+    # /services/:id
+    def update(self, request, pk):
+        """Handle PUT requests for a service"""
+        try:
+            service = Service.objects.get(pk=pk)
+            service.category = Category.objects.get(
+                pk=request.data["category"])
+            service.name = request.data["name"]
+            service.description = request.data["description"]
+            service.duration = request.data["duration"]
+            service.price = request.data["price"]
+            service.image_url = request.data.get("image_url", "")
+            service.active = request.data.get("active", True)
+            service.save()
+            serializer = ServiceSerializer(service)
+            return Response(serializer.data)
+        except Service.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+    # /services/:id
+    def destroy(self, request, pk):
+        """Handle DELETE requests for a service"""
+        try:
+            service = Service.objects.get(pk=pk)
+            service.delete()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except Service.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+    # get stylists of a service
+    # /services/:id/stylists
+    # with the action decorator, the router you already registered will auto‑create the URL route stylists
+    @action(methods=['get'], detail=True)
+    def stylists(self, request, pk):
+        """Handle GET requests for stylists of a service"""
+        try:
+            service = Service.objects.get(pk=pk)
+            # find all join rows for this service
+            stylist_links = StylistService.objects.filter(service=service)
+            # get all stylists (UserInfo objs) from the join rows
+            stylists = [link.stylist for link in stylist_links]
+            serializer = UserInfoSerializer(stylists, many=True)
+            return Response(serializer.data)
+        except Service.DoesNotExist as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+    # /services/:id/add_stylist
+    @action(methods=['post'], detail=True)
+    def add_stylist(self, request, pk):
+        """Handle POST requests to add a stylist to a service"""
+        try:
+            service = Service.objects.get(pk=pk)
+            stylist = UserInfo.objects.get(pk=request.data["stylist"])
+            obj, created = StylistService.objects.get_or_create(
+                service=service, stylist=stylist)
+            if not created:
+                return Response({'message': 'Stylist already offers this service'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(status=status.HTTP_201_CREATED)
+        except (Service.DoesNotExist, UserInfo.DoesNotExist) as ex:
+            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+    # /services/:id/remove_stylist/stylistId=:id
+    @action(methods=['delete'], detail=True)
+    def remove_stylist(self, request, pk):
+        """Handle DELETE requests to remove a stylist from a service"""
+        # get the stylistId from the query params
+        stylist_id = request.query_params.get("stylistId", None)
+        if stylist_id is None:
+            return Response({'message': 'Missing stylistId query parameter'}, status=status.HTTP_400_BAD_REQUEST)
+        # delete the link row
+        try:
+            link = StylistService.objects.get(stylist=stylist_id, service=pk)
+            link.delete()
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except StylistService.DoesNotExist as ex:
             return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
This pull request significantly expands the `ServiceView` in `tressreliefapi/views/service.py` to provide full CRUD operations for services and adds endpoints to manage the relationship between services and stylists. The changes introduce several new API endpoints and supporting logic for associating stylists with services.

**Service CRUD operations:**

* Added `create`, `update`, and `destroy` methods to support POST, PUT, and DELETE operations for the `Service` model, enabling clients to add, modify, and remove services via the API.

**Stylist-service relationship management:**

* Introduced the `stylists` action to retrieve all stylists (as `UserInfo` objects) associated with a specific service.
* Added the `add_stylist` action to allow associating a stylist with a service, with logic to prevent duplicate associations.
* Added the `remove_stylist` action to remove a stylist from a service, using a query parameter to specify the stylist.

**Imports and setup:**

* Updated imports to include `StylistService`, `UserInfo`, and `UserInfoSerializer`, and imported the `action` decorator to support the new custom endpoints.

Completes tickets 35, 26, 27, 28, 29, and 30