### PR TITLE
added oauth google initiate endpoint which returns consent url

### DIFF
--- a/tressreliefapi/views/__init__.py
+++ b/tressreliefapi/views/__init__.py
@@ -2,3 +2,4 @@ from .auth import get_or_create_user
 from .user_info import UserInfoView
 from .category import CategoryView
 from .service import ServiceView
+from .oauth import oauth_google_initiate

--- a/tressreliefapi/views/oauth.py
+++ b/tressreliefapi/views/oauth.py
@@ -1,0 +1,50 @@
+from urllib.parse import urlencode
+from django.conf import settings
+from django.http import JsonResponse
+
+# DOCS: https://developers.google.com/identity/protocols/oauth2/web-server
+
+SCOPES = [
+    # needed to create/update/delete events on stylist's calendar
+    "https://www.googleapis.com/auth/calendar.events",
+    # needed to read the stylist's busy times to generate availability
+    "https://www.googleapis.com/auth/calendar.readonly",
+]
+
+# /oauth/google/initiate/
+
+
+def oauth_google_initiate(request):
+    """ Initiate the OAuth2 flow by redirecting to Google's OAuth 2.0 server
+        to obtain user consent for the requested scopes.
+        Returns a JSON response containing the URL to redirect the user to."""
+    params = {
+        # OAuth client ID i got from google cloud
+        "client_id": settings.GOOGLE_CLIENT_ID,
+        # matches what i set in google cloud
+        "redirect_uri": settings.GOOGLE_REDIRECT_URI,
+        # we want an authorization code back (this will be used in the callback url we redirect to, to get access/refresh tokens)
+        "response_type": "code",
+        # URL-encoded list of permissions... here we want calendar access. these values inform the consent screen the user sees
+        "scope": " ".join(SCOPES),
+        # we want a refresh token ("Indicates whether your application can refresh access tokens when the user is not present at the browser.")
+        "access_type": "offline",
+        # forces the consent screen to always show (to get refresh token each time)
+        "prompt": "consent",
+    }
+    url = f"https://accounts.google.com/o/oauth2/v2/auth?{urlencode(params)}"
+    return JsonResponse({"url": url})
+
+# google consent url structure (example):
+# https://accounts.google.com/o/oauth2/v2/auth?
+# client_id=110025474277-rp86u96j9pplrmma9aknmegc1ongn48p.apps.googleusercontent.com
+# &redirect_uri=http://localhost:8000/oauth/google/callback/
+# &response_type=code
+# &scope=https://www.googleapis.com/auth/calendar.events https://www.googleapis.com/auth/calendar.readonly
+# &access_type=offline
+# &include_granted_scopes=true
+# &prompt=consent
+
+# front-end will call this endpoint (when a stylist clicks a button to connect their Google Calendar), get back the conxsent url, and redirect the stylist to it
+# stylist will log in to google and approve the requested permissions
+# after the user clicks allow, then google will redirect to my redirect uri (which i set in google cloud console), which i will make an endpoint for next

--- a/tressreliefproject/urls.py
+++ b/tressreliefproject/urls.py
@@ -4,7 +4,7 @@ from rest_framework import routers
 from tressreliefapi.views import get_or_create_user, UserInfoView, CategoryView, ServiceView
 from tressreliefapi.views.service_stylists_options import ServiceStylistOptions
 from tressreliefapi.views.stylist_service import StylistServiceLinks
-
+from tressreliefapi.views.oauth import oauth_google_initiate
 
 # The first parameter, r'userinfo, is setting up the url.
 # The second UserInfoView is telling the server which view to use when it sees that url.
@@ -22,4 +22,5 @@ urlpatterns = [
     path("get-or-create-user", get_or_create_user),
     path("stylist-services", StylistServiceLinks.as_view()),
     path("service-stylist-options", ServiceStylistOptions.as_view()),
+    path("oauth/google/initiate", oauth_google_initiate),
 ]


### PR DESCRIPTION
(tested in postman, got link back, works in broswer. it redirects to my redirect url, which is what i will work on next). detailed notes in notion.

This pull request adds the initial backend support for integrating Google OAuth2 authentication, specifically to allow stylists to connect their Google Calendar accounts. The main change is the introduction of an endpoint that generates and returns the Google OAuth2 consent URL, which the front-end can use to initiate the OAuth flow.

### Google OAuth2 Integration

* Added a new view function `oauth_google_initiate` in `tressreliefapi/views/oauth.py` that constructs the Google OAuth2 consent URL with the necessary scopes for calendar access and returns it as a JSON response.
* Registered the new endpoint `/oauth/google/initiate` in `tressreliefproject/urls.py`, making it available for front-end use.
* Imported `oauth_google_initiate` in both `tressreliefapi/views/__init__.py` and `tressreliefproject/urls.py` to ensure the view is accessible and properly routed. [[1]](diffhunk://#diff-e909aab695b34a22169e9eea05817ac60db99e0c61f2358a549e98a09cef1e44R5) [[2]](diffhunk://#diff-07fa7addfaca10eac40f9be921e954766b7dc506a7aa943b9b1f18c70ee98f81L7-R7)