### PR TITLE
Utility to refresh access token if expired, and regardless returns access token for use in future api calls to google (AT6)

### DIFF
--- a/tressreliefapi/google_utils.py
+++ b/tressreliefapi/google_utils.py
@@ -1,0 +1,50 @@
+# Access tokens only last an hour, so will need to use the refresh token to get new access tokens when they expire. This helper will make sure tokens are valid before any google api request.
+
+# DOCS: Refrshing an access token (offline access): https://developers.google.com/identity/protocols/oauth2/web-server#offline
+
+import datetime
+import requests
+from tressreliefapi.models.oauth_credential import OAuthCredential
+from django.conf import settings
+from django.utils import timezone
+
+
+def get_valid_access_token(user):
+    """ Ensure the stylist has a valid Google access token. 
+    Refresh if expired, then return the token."""
+
+    # 1.) Look up the stylit's OAuthCredential
+    try:
+        credential = OAuthCredential.objects.get(user=user, provider='google')
+    except OAuthCredential.DoesNotExist:
+        return None  # stylist hasn't connected their google account yet
+
+    # 2.) Check if token_expiry is in the valid still (if it is greater than 'now'), if so return the access token
+    if credential.token_expiry and credential.token_expiry > timezone.now():
+        return credential.access_token
+
+    # 3.) othwerwise (if token_expiry is in the past (invalid)), call google's token refresh endpoint with the stored refresh_token (docs linked above).
+    else:
+        data = {
+            "client_id": settings.GOOGLE_CLIENT_ID,  # from google cloud
+            "client_secret": settings.GOOGLE_CLIENT_SECRET,  # from google cloud
+            # tells google what kind of exchange this is, docs say it must be this value
+            "grant_type": 'refresh_token',
+            "refresh_token": credential.refresh_token,
+        }
+        response = requests.post(
+            # the following returns json with new access token and expiry time if successful
+            'https://oauth2.googleapis.com/token', data=data)
+        if response.status_code != 200:  # if refresh failed
+            return None
+        else:  # refresh successful
+            tokens = response.json()
+
+            credential.access_token = tokens["access_token"]
+            # default to 1 hour if missing
+            expires_in = tokens.get("expires_in", 3600)
+            credential.token_expiry = timezone.now() + datetime.timedelta(seconds=expires_in)
+    # 4.) (cont on step 3) save the new access token and expiry time back to the DB
+            credential.save()
+    # 5.) return valid access token for use in future api calls
+            return credential.access_token

--- a/tressreliefapi/models/oauth_credential.py
+++ b/tressreliefapi/models/oauth_credential.py
@@ -5,6 +5,8 @@ from .user_info import UserInfo
 # 1.) read the stylists busy times and generate available slots for clients
 # 2.) create/update/cancel events on the stylists calendar
 
+# DOCS: https://developers.google.com/identity/protocols/oauth2/web-server#offline
+
 
 class OAuthCredential(models.Model):
     # links the credentials to which stylist they belong to


### PR DESCRIPTION
This pull request introduces a helper function to ensure Google access tokens are valid before making API requests, and includes several improvements and clarifications to the OAuth credential handling and callback flow. The primary goal is to reliably manage token expiry and refresh logic for Google API integration.

**Google OAuth token management improvements:**

* Added `get_valid_access_token` helper in `google_utils.py` to automatically refresh expired Google access tokens using the stored refresh token and save the new token and expiry in the database.

**Documentation and code clarity:**

* Added documentation references and comments in `oauth_credential.py` and `oauth_callback.py` explaining the OAuth flow and relevant Google documentation for offline access and token refresh. [[1]](diffhunk://#diff-34f103c69593e7586852497f58c64061afc3510858623c762f5238cc7cf97218R8-R9) [[2]](diffhunk://#diff-2de3832cd1dbb0df1108ec3fef4cfbe656547d0d20509e2f828e010a16dbbcbbR1-R2)