### PR TITLE
Basic crud OAuth_credential model viewset. For deleting cred/google cal connection purposes.

### DIFF
--- a/tressreliefapi/serializers/__init__.py
+++ b/tressreliefapi/serializers/__init__.py
@@ -2,3 +2,4 @@ from .user_info import UserInfoSerializer
 from .category import CategorySerializer
 from .service import ServiceSerializer
 from .stylist_service import StylistServiceSerializer
+from .oauth_credential import OAuthCredentialSerializer

--- a/tressreliefapi/serializers/oauth_credential.py
+++ b/tressreliefapi/serializers/oauth_credential.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from tressreliefapi.models import OAuthCredential
+
+
+class OAuthCredentialSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = OAuthCredential
+        fields = '__all__'

--- a/tressreliefapi/views/__init__.py
+++ b/tressreliefapi/views/__init__.py
@@ -4,3 +4,4 @@ from .category import CategoryView
 from .service import ServiceView
 from .oauth import oauth_google_initiate
 from .oauth_callback import oauth_google_callback
+from .oauth_credential import OAuthCredentialViewSet

--- a/tressreliefapi/views/oauth_credential.py
+++ b/tressreliefapi/views/oauth_credential.py
@@ -1,0 +1,13 @@
+from rest_framework import viewsets
+from rest_framework.permissions import IsAdminUser
+from tressreliefapi.models import OAuthCredential
+from tressreliefapi.serializers.oauth_credential import OAuthCredentialSerializer
+
+
+class OAuthCredentialViewSet(viewsets.ModelViewSet):
+    """
+    CRUD for OAuth credentials.
+    """
+    queryset = OAuthCredential.objects.all()
+    serializer_class = OAuthCredentialSerializer
+    permission_classes = []

--- a/tressreliefproject/urls.py
+++ b/tressreliefproject/urls.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
-from tressreliefapi.views import get_or_create_user, UserInfoView, CategoryView, ServiceView
+from tressreliefapi.views import get_or_create_user, UserInfoView, CategoryView, ServiceView, OAuthCredentialViewSet
 from tressreliefapi.views.service_stylists_options import ServiceStylistOptions
 from tressreliefapi.views.stylist_service import StylistServiceLinks
 from tressreliefapi.views.oauth import oauth_google_initiate
@@ -15,6 +15,9 @@ router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'userinfo', UserInfoView, 'userinfo')
 router.register(r'categories', CategoryView, 'category')
 router.register(r'services', ServiceView, 'service')
+router.register(r'oauth-credentials',
+                OAuthCredentialViewSet, 'oauthcredential')
+
 
 # Each path() in urlpatterns is mapping a URL pattern to a view — which is just the code that runs when someone visits that URL.
 urlpatterns = [


### PR DESCRIPTION
This pull request introduces a new API endpoint for managing OAuth credentials, including the necessary serializer, viewset, and URL routing. The main changes are grouped into API feature additions and integration updates.

**New OAuth Credential Management API:**

* Added `OAuthCredentialSerializer` in `tressreliefapi/serializers/oauth_credential.py` to serialize all fields of the `OAuthCredential` model.
* Created `OAuthCredentialViewSet` in `tressreliefapi/views/oauth_credential.py` to provide CRUD operations for OAuth credentials.

**Integration of OAuth Credential API:**

* Registered `OAuthCredentialViewSet` in the main API router in `tressreliefproject/urls.py`, exposing the new endpoint at `/oauth-credentials/`. [[1]](diffhunk://#diff-07fa7addfaca10eac40f9be921e954766b7dc506a7aa943b9b1f18c70ee98f81L4-R4) [[2]](diffhunk://#diff-07fa7addfaca10eac40f9be921e954766b7dc506a7aa943b9b1f18c70ee98f81R18-R20)
* Imported the new serializer and viewset in the relevant `__init__.py` files for proper module exposure. [[1]](diffhunk://#diff-0e8f40258682dd4eb3ca4c084ee99ad6f3c254a16bb37346265714c13fa2788fR5) [[2]](diffhunk://#diff-e909aab695b34a22169e9eea05817ac60db99e0c61f2358a549e98a09cef1e44R7)