### PR TITLE
Updates to OAuth cred initiate and callback to work with FE user. Added OAuth status endpoint.

### DIFF
--- a/tressreliefapi/views/oauth_status.py
+++ b/tressreliefapi/views/oauth_status.py
@@ -1,0 +1,38 @@
+# get whether stylist has connected their google calendar (for use in FE to show connected state vs connect button)
+
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework import status
+from tressreliefapi.models.oauth_credential import OAuthCredential
+from tressreliefapi.models.user_info import UserInfo
+
+# http://localhost:8000/oauth/google/status
+# (include in headerL: Authorization: <stylist uid>)
+
+
+@api_view(['GET'])
+def oauth_google_status(request):
+    """Return whether stylist has connected their Google Calendar"""
+    # for now, assume user is the first stylist in the db (later (TODO:) will get user from auth token in request header)
+    uid = request.headers.get("Authorization")
+    if not uid:
+        return Response({"error": "Missing Authorization header"}, status=status.HTTP_401_UNAUTHORIZED)
+
+  # look up user by uid
+    try:
+        user = UserInfo.objects.get(uid=uid)
+    except UserInfo.DoesNotExist:
+        return Response({"error": "User not found"}, status=status.HTTP_404_NOT_FOUND)
+
+  # goal is that only stylists can connect google calendar, but for now i only protect that on the frontend (later TODO:)
+
+  # look up OAuthCredential for this user and return whether it exists as true (including calendar_id and updated_at) or false (if it does, they have connected their calendar)
+    try:
+        cred = OAuthCredential.objects.get(user=user, provider="google")
+        return Response({
+            "connected": True,
+            "calendar_id": cred.calendar_id,
+            "updated_at": cred.token_expiry
+        })
+    except OAuthCredential.DoesNotExist:
+        return Response({"connected": False})

--- a/tressreliefproject/urls.py
+++ b/tressreliefproject/urls.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.urls import include, path
 from rest_framework import routers
 from tressreliefapi.views import get_or_create_user, UserInfoView, CategoryView, ServiceView, OAuthCredentialViewSet
+from tressreliefapi.views.oauth_status import oauth_google_status
 from tressreliefapi.views.service_stylists_options import ServiceStylistOptions
 from tressreliefapi.views.stylist_service import StylistServiceLinks
 from tressreliefapi.views.oauth import oauth_google_initiate
@@ -28,5 +29,6 @@ urlpatterns = [
     path("service-stylist-options", ServiceStylistOptions.as_view()),
     path("oauth/google/initiate", oauth_google_initiate),
     # the trailing slash is important below (in callback) because google will redirect to this exact url with the code query param added onto the end
-    path("oauth/google/callback/", oauth_google_callback)
+    path("oauth/google/callback/", oauth_google_callback),
+    path("oauth/google/status", oauth_google_status),
 ]


### PR DESCRIPTION
This pull request improves the Google OAuth flow for stylists, making it more secure and user-specific, and adds an endpoint for the front-end to check if a stylist has connected their Google Calendar. The changes ensure that the stylist's unique identifier (`uid`) is passed through the authentication process, used for database lookups, and included in status checks.

**Google OAuth flow improvements:**

* The `oauth_google_initiate` endpoint now requires the stylist's `uid` in the Authorization header and passes it through the OAuth flow using the state parameter, improving user identification and security. [[1]](diffhunk://#diff-042d25cbba7e0b7f956d4797060887243fde3dd39fc5870ce7cef84517abb10dR1-R2) [[2]](diffhunk://#diff-042d25cbba7e0b7f956d4797060887243fde3dd39fc5870ce7cef84517abb10dR23-R28) [[3]](diffhunk://#diff-042d25cbba7e0b7f956d4797060887243fde3dd39fc5870ce7cef84517abb10dR42)
* The `oauth_google_callback` endpoint now retrieves the stylist's `uid` from the state parameter, looks up the stylist in the database by `uid`, and returns a 404 error if not found, ensuring the OAuth credentials are linked to the correct user. [[1]](diffhunk://#diff-2de3832cd1dbb0df1108ec3fef4cfbe656547d0d20509e2f828e010a16dbbcbbR32-R36) [[2]](diffhunk://#diff-2de3832cd1dbb0df1108ec3fef4cfbe656547d0d20509e2f828e010a16dbbcbbL63-R73)

**Front-end integration and user experience:**

* After successful OAuth connection, the callback endpoint redirects the stylist to the front-end stylists page instead of returning a JSON response.

**Status endpoint for calendar connection:**

* Added a new `oauth_google_status` endpoint that checks if a stylist has connected their Google Calendar, returning connection status and calendar details for use in the front-end UI.

**URL routing updates:**

* Registered the new status endpoint in `tressreliefproject/urls.py` for API access. [[1]](diffhunk://#diff-07fa7addfaca10eac40f9be921e954766b7dc506a7aa943b9b1f18c70ee98f81R5) [[2]](diffhunk://#diff-07fa7addfaca10eac40f9be921e954766b7dc506a7aa943b9b1f18c70ee98f81L31-R33)